### PR TITLE
fixes contract inheritance

### DIFF
--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -59,6 +59,8 @@ module Ethereum
         raise "No contracts compiled" if contracts.empty?
         if contract_index
           contract = contracts[contract_index].class_object.new
+        elsif name
+          contract = contracts.find { |x| x.name.to_s == name.to_s }.class_object.new
         else
           contract = contracts.first.class_object.new
         end

--- a/spec/ethereum/contract_inheritance_spec.rb
+++ b/spec/ethereum/contract_inheritance_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Ethereum::Contract do
+
+  let(:client) { Ethereum::IpcClient.new }
+  let(:name) { "ContractWithInheritance" }
+  let(:path) { "#{Dir.pwd}/spec/fixtures/#{name}.sol" }
+
+  describe "create" do
+    it "uses the name to extract the correct contract from solidity compilation" do
+      @incorrect = Ethereum::Contract.create(file: path, client: client)
+      expect(@incorrect.parent.class_object.to_s).to eq("Ethereum::Contract::ContractParent1")
+
+      @correct = Ethereum::Contract.create(file: path, client: client, name: name)
+      expect(@correct.parent.class_object.to_s).to eq("Ethereum::Contract::#{name}")
+    end
+  end
+
+end

--- a/spec/fixtures/ContractParent1.sol
+++ b/spec/fixtures/ContractParent1.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.8;
+
+contract ContractParent1 {
+
+}

--- a/spec/fixtures/ContractParent2.sol
+++ b/spec/fixtures/ContractParent2.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.8;
+
+contract ContractParent2 {
+
+}

--- a/spec/fixtures/ContractWithInheritance.sol
+++ b/spec/fixtures/ContractWithInheritance.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.8;
+
+import './ContractParent1.sol';
+import './ContractParent2.sol';
+
+contract ContractWithInheritance is ContractParent1, ContractParent2 {
+
+}


### PR DESCRIPTION
It is expected that the first compiled contract from solc be the contract being created. solc returns the compiled contracts in no specific order, thus sometimes inheritance is broken.

This PR will allow the `name` argument to be used to locate the correct compiled contract from solc. 